### PR TITLE
fix: support multiple TourSpots in PresetTour struct.

### DIFF
--- a/ptz/types.go
+++ b/ptz/types.go
@@ -220,7 +220,7 @@ type GetPresetTours struct {
 }
 
 type GetPresetToursResponse struct {
-	PresetTour onvif.PresetTour
+	PresetTour []onvif.PresetTour
 }
 
 type GetPresetTour struct {

--- a/xsd/onvif/onvif.go
+++ b/xsd/onvif/onvif.go
@@ -1176,7 +1176,7 @@ type PresetTour struct {
 	Status            PTZPresetTourStatus            `xml:"Status"`
 	AutoStart         xsd.Boolean                    `xml:"AutoStart"`
 	StartingCondition PTZPresetTourStartingCondition `xml:"StartingCondition"`
-	TourSpot          PTZPresetTourSpot              `xml:"TourSpot"`
+	TourSpot          []PTZPresetTourSpot           	 `xml:"TourSpot"`
 	Extension         PTZPresetTourExtension         `xml:"Extension"`
 }
 


### PR DESCRIPTION
TourSpot was defined as a single PTZPresetTourSpot value, making it impossible to configure a preset tour with more than one stop. The ONVIF spec allows multiple TourSpot entries per tour, so this changes the field to a slice.